### PR TITLE
Support ignoring selected local variables

### DIFF
--- a/lib/memo/it.rb
+++ b/lib/memo/it.rb
@@ -1,9 +1,13 @@
 module Memo
   VERSION = '0.1.2'
   module It
-    def memo(&block)
+    def memo(ignore: [], &block)
       keys = block.source_location
-      keys << block.binding.local_variables.map { |name| [name, block.binding.local_variable_get(name)] }
+      ignore = Array(ignore)
+      keys << block.binding.local_variables.map do |name|
+        next if ignore.include?(name)
+        [name, block.binding.local_variable_get(name)]
+      end
       keys = keys.flatten.map(&:to_s)
 
       @_memo_it ||= {}

--- a/test/memo/it_test.rb
+++ b/test/memo/it_test.rb
@@ -36,6 +36,39 @@ module Memo
       @mock.verify
     end
 
+    def test_memoizes_without_single_ignored_variable
+      @mock.expect(:slow, :stuff12, [1, 2])
+      10.times { assert memo_with_single_ignored_parameter(1,2) == :stuff12 }
+
+      # does not call the block if ignored parameter is changed
+      10.times { assert memo_with_single_ignored_parameter(3,2) == :stuff12 }
+
+      # but calls the block if not-ignored parameters is changed
+      @mock.expect(:slow, :stuff14, [1, 4])
+      10.times { assert memo_with_single_ignored_parameter(1,4) == :stuff14 }
+
+      @mock.verify
+    end
+
+    def test_memoizes_without_multiple_ignored_variables
+      @mock.expect(:slow, :stuff123, [1, 2, 3])
+      10.times { assert memo_with_multiple_ignored_parameters(1,2,3) == :stuff123 }
+
+      # does not call the block if first ignored parameter is changed
+      10.times { assert memo_with_multiple_ignored_parameters(4,2,3) == :stuff123 }
+
+      # does not call the block if second ignored parameter is changed
+      10.times { assert memo_with_multiple_ignored_parameters(1,2,4) == :stuff123 }
+
+      # but calls the block if not-ignored parameters is changed
+      @mock.expect(:slow, :stuff143, [1, 4, 3])
+      10.times { assert memo_with_multiple_ignored_parameters(1,4, 3) == :stuff143 }
+
+      @mock.verify
+    end
+
+    private
+
     def memo_without_parameters
       memo do
         @mock.slow
@@ -45,6 +78,18 @@ module Memo
     def memo_with_parameters(some = 1, parameters = 2)
       memo do
         @mock.slow(some, parameters)
+      end
+    end
+
+    def memo_with_single_ignored_parameter(some = 1, parameters = 2)
+      memo(ignore: :some) do
+        @mock.slow(some, parameters)
+      end
+    end
+
+    def memo_with_multiple_ignored_parameters(some = 1, more = 2, parameters = 3)
+      memo(ignore: [:some, :parameters]) do
+        @mock.slow(some, more, parameters)
       end
     end
   end


### PR DESCRIPTION
It would be nice (actually it's something we need) to be able to ignore certain local variables from being key'ed into the memoisation:

```ruby
  def load_repo(name =  'memo-it', time = Time.now)
    memo(ignore: :time) do
      # in this case the result will be memoized per name
      HTTPClient.get("https://github.com/phoet/#{name}?time=#{time}")
    end
  end
```

or with multiple parameters

```ruby
  def load_repo(name =  'memo-it', time = Time.now, other = 'wat')
    memo(ignore: [:time, :other]) do
      # in this case the result will be memoized per name
      HTTPClient.get("https://github.com/phoet/#{name}?time=#{time}&other=#{other}")
    end
  end
```

Will add that feature to the README if you are going to accept that change request.