### PR TITLE
make it a tad faster

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'byebug'
+gem 'benchmark-ips'
+gem 'memoist'

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,38 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
+  t.libs << 'test'
+  t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-task :default => :test
+task default: :test
+
+task :benchmark do
+  require_relative 'lib/memo/it'
+  require 'benchmark/ips'
+  require 'memoist'
+
+  class Tester
+    extend Memoist
+
+    def memo_it
+      memo { false }
+    end
+
+    def memoist
+      false
+    end
+
+    memoize :memoist
+  end
+
+  tester = Tester.new
+  Benchmark.ips do |x|
+    x.warmup = 3
+    x.time = 10
+    x.report('memo-it') { tester.memo_it }
+    x.report('memoist') { tester.memoist }
+  end
+end

--- a/lib/memo/it.rb
+++ b/lib/memo/it.rb
@@ -27,8 +27,7 @@ module Memo
       end
 
       keys = block.source_location
-      keys << key_names.map { |name| [name, block.binding.local_variable_get(name)] }
-      keys = keys.flatten.map(&:to_s)
+      keys << key_names.flat_map { |name| [name, block.binding.local_variable_get(name)] }
 
       @_memo_it ||= {}
       return @_memo_it[keys] if Memo.enabled? && @_memo_it.key?(keys)


### PR DESCRIPTION
out of curiosity from issue #6 i picked up that code in order to see what exactly is slow in the implementation.

it's actually not the code itself but the overhead that the block adds to the execution time.

i removed the `to_s` mapping for the keys as it should not be necessary or might even have unwanted sideffects.

/cc @alto 