### PR TITLE
use a class level variable

### DIFF
--- a/lib/memo/it.rb
+++ b/lib/memo/it.rb
@@ -15,6 +15,14 @@ module Memo
     @enabled = false
   end
 
+  def self.cache
+    @cache ||= {}
+  end
+
+  def self.clear
+    cache.clear
+  end
+
   module It
     def memo(only: [], except: [], &block)
       only = Array(only)
@@ -29,9 +37,8 @@ module Memo
       keys = block.source_location
       keys << key_names.flat_map { |name| [name, block.binding.local_variable_get(name)] }
 
-      @_memo_it ||= {}
-      return @_memo_it[keys] if Memo.enabled? && @_memo_it.key?(keys)
-      @_memo_it[keys] = yield
+      return Memo.cache[keys] if Memo.enabled? && Memo.cache.key?(keys)
+      Memo.cache[keys] = yield
     end
   end
 end

--- a/test/memo/it_test.rb
+++ b/test/memo/it_test.rb
@@ -6,6 +6,10 @@ module Memo
       @mock = MiniTest::Mock.new
     end
 
+    def teardown
+      Memo.clear
+    end
+
     def test_disabling
       assert Memo.enabled?
       Memo.disable


### PR DESCRIPTION
when using memo-it within a rails helper it would not behave as expected. i assume this is due to how rails dynamically adds the helper modules.

with this change, memo-it does not leak it's state into the included object but contains everything within it's own namespace.

/cc @alto 