### PR TITLE
Memo conflict when memoising within objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # personal version manager settings
 .ruby-version
 .ruby-gemset
+
+# debugging files
+.byebug_history

--- a/lib/memo/it.rb
+++ b/lib/memo/it.rb
@@ -35,6 +35,7 @@ module Memo
       end
 
       keys = block.source_location
+      keys << object_id
       keys << key_names.flat_map { |name| [name, block.binding.local_variable_get(name)] }
 
       return Memo.cache[keys] if Memo.enabled? && Memo.cache.key?(keys)

--- a/memo-it.gemspec
+++ b/memo-it.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "> 1.0"
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "minitest", "> 5.0"
+  spec.add_development_dependency "mocha"
 end

--- a/test/helpers/memo_cat.rb
+++ b/test/helpers/memo_cat.rb
@@ -1,0 +1,9 @@
+class MemoCat
+  def calculate; end
+
+  def result
+    memo do
+      calculate
+    end
+  end
+end

--- a/test/memo/it_test.rb
+++ b/test/memo/it_test.rb
@@ -33,6 +33,18 @@ module Memo
       @mock.verify
     end
 
+    def test_memoizes_per_object
+      cat1 = MemoCat.new
+      cat1.expects(:calculate).returns('result1')
+      cat2 = MemoCat.new
+      cat2.expects(:calculate).returns('result2')
+
+      10.times do
+        assert_equal 'result1', cat1.result
+        assert_equal 'result2', cat2.result
+      end
+    end
+
     def test_memoizes_nil
       @mock.expect(:slow, nil)
       10.times { assert memo_without_parameters.nil? }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,5 @@ require 'byebug'
 
 require 'minitest/autorun'
 require 'mocha/mini_test'
+
+Dir[File.dirname(__FILE__) + "/helpers/*.rb"].sort.each { |f| require File.expand_path(f) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,4 @@ require 'memo/it'
 require 'byebug'
 
 require 'minitest/autorun'
+require 'mocha/mini_test'


### PR DESCRIPTION
When memoising an instance method

```ruby
class MemoCat
  def initialize(name)
    @name = name
  end

  def calculate
    @name # just to show the problem
  end

  def result
    memo do
      calculate
    end
  end
end
```

the result of the method is not memoised on a per-object base:

```ruby
cat1 = MemoCat.new('cat1')
cat2 = MemoCat.new('cat2'

cat1.result
# => 'cat1'
cat2.result
# => 'cat1' # MEH
```

This PR fixes that problem /cc @phoet 