### PR TITLE
failing specs for multiple memos in a row

### DIFF
--- a/test/memo/it_test.rb
+++ b/test/memo/it_test.rb
@@ -124,6 +124,28 @@ module Memo
       @mock.verify
     end
 
+    class MyMemoTest
+      attr_accessor :what
+
+      def one_line
+        memo { @what } ? memo { :foo } : memo { :bar }
+      end
+    end
+
+    def test_memo_thrice_in_row_left
+      dut = MyMemoTest.new
+      dut.what = true
+      assert_equal(:foo, dut.one_line)
+      assert_equal(2, dut.instance_variable_get(:@_memo_it).size, "Two memos should have two entries")
+    end
+
+    def test_memo_thrice_in_row_right
+      dut = MyMemoTest.new
+      dut.what = false
+      assert_equal(:bar, dut.one_line)
+      assert_equal(2, dut.instance_variable_get(:@_memo_it).size, "Two memos should have two entries")
+    end
+
     private
 
     def memo_without_parameters


### PR DESCRIPTION
Hi phoet,

I think, I found a flaw when someone tries to use memos in one line and here are failing specs for this case.

A ternary operator is sensitive to this kind of flaw for instance, something like:
```
def whatever
  @x ? memo {:foo} : memo {:bar}  
end
```