### PR TITLE
Small docker compose setup to facilitate dev work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2.6.0
+
+RUN mkdir -p /app/source
+WORKDIR /app/source
+ADD . /app/source
+
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends bash vim g++ make && \
+	rm -rf /var/lib/apt/lists/*
+
+CMD /bin/bash

--- a/bin/dev-memo-it
+++ b/bin/dev-memo-it
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euxo pipefail
+
+SERVICE=memo-it-client
+
+volumes=(ruby-2.6.0-bundle)
+
+for v in ${volumes[@]}; do
+  echo ${v}
+  if ! docker volume ls -q | grep -e ^${v}$ >/dev/null
+  then
+    docker volume create --name ${v}
+  fi
+done
+
+docker-compose up --no-recreate -d ${SERVICE}
+
+COMMAND=${@:-bash}
+echo Run \'$COMMAND\' in container context
+
+docker exec -ti ${SERVICE} ${COMMAND}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  memo-it-client: &default
+    container_name: memo-it-client
+    build: .
+    working_dir: /app/source
+    tty: true
+    volumes:
+      - .:/app/source
+      - ruby-2.6.0-bundle:/usr/local/bundle
+    environment:
+      BUNDLE_GEMFILE: /app/source/Gemfile
+
+volumes:
+  ruby-2.6.0-bundle:
+    external: true


### PR DESCRIPTION
I use this small setup to relieve my host machine from installing anything for dev purposes.
3 small files.

Dockerfile
docker-compose.yml
bin/dev-memo-it

Just run:
```
host $ bin/dev-memo-it
...
root@ba29052e7716:/app/source#
```
and you are dropped into a console in the container, in which all your commands (setup, install, etc. work)